### PR TITLE
Fix iwd/how interaction by p_zombie

### DIFF
--- a/SandrahNPC/IWD/HOWTOEET.baf
+++ b/SandrahNPC/IWD/HOWTOEET.baf
@@ -1,0 +1,65 @@
+IF
+	True()
+THEN
+	RESPONSE #100
+		CutSceneId(Player1)
+		Wait(1)
+		LeaveAreaLUAPanic("BG0702","",[393.314],14)
+		LeaveAreaLUA("BG0702","",[393.314],14)
+		ActionOverride(Player2,LeaveAreaLUA("BG0702","",[361.353],6))
+		ActionOverride(Player3,LeaveAreaLUA("BG0702","",[440.387],12))
+		ActionOverride(Player4,LeaveAreaLUA("BG0702","",[471.354],4))
+		ActionOverride(Player5,LeaveAreaLUA("BG0702","",[328.305],2))
+		ActionOverride(Player6,LeaveAreaLUA("BG0702","",[488.388],10))
+		SetGlobal("PARTY_IN_ICEWIND_DALE","GLOBAL",0)
+		Wait(1)
+		SetSequence(SEQ_SLEEP)
+		ActionOverride(Player2,SetSequence(SEQ_SLEEP))
+		ActionOverride(Player3,SetSequence(SEQ_SLEEP))
+		ActionOverride(Player4,SetSequence(SEQ_SLEEP))
+		ActionOverride(Player5,SetSequence(SEQ_SLEEP))
+		ActionOverride(Player6,SetSequence(SEQ_SLEEP))
+		//MoveGlobal("FC0125","fcsherri",[737.773])
+		//ActionOverride("fcsherri",FaceObject(Player1))
+		Wait(1)
+		FadeFromColor([15.0],0)
+		Wait(1)
+		//MoveContainerContents("BG0125*IdImportContainer","FC0125*IdImportContainer")
+		Wait(2)
+		SetSequence(SEQ_AWAKE)
+		ActionOverride(Player2,SetSequence(SEQ_AWAKE))
+		ActionOverride(Player3,SetSequence(SEQ_AWAKE))
+		ActionOverride(Player4,SetSequence(SEQ_AWAKE))
+		ActionOverride(Player5,SetSequence(SEQ_AWAKE))
+		ActionOverride(Player6,SetSequence(SEQ_AWAKE))
+		Wait(1)
+		//SetGlobal("SHERRY_PLOT","GLOBAL",81)
+		EndCutSceneMode()
+		//SetCutSceneLite(TRUE)
+		//ActionOverride("fcsherri",StartDialogNoSet(Player1))
+END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/SandrahNPC/IWD/id9603howend.baf
+++ b/SandrahNPC/IWD/id9603howend.baf
@@ -44,5 +44,5 @@ ApplySpellRES("clearcld",Player1)
 Wait(1)
 FadeFromColor([0.0],0)
 ClearAllActions()
-StartCutScene("IDTOEET1")
+StartCutScene("HOWTOEET")
 END

--- a/SandrahNPC/Jenlig/CVJenlig.baf
+++ b/SandrahNPC/Jenlig/CVJenlig.baf
@@ -669,6 +669,7 @@ DisplayStringHead(Myself,@826)
 END
 
 IF
+!Global("PARTY_IN_ICEWIND_DALE","GLOBAL",1)
 !HasItem("CVJensw",Myself)
 !HasItem("CVJensw",Player1)
 !HasItem("CVJensw",Player2)
@@ -687,6 +688,7 @@ ActionOverride(Player6,PickUpItem("CVJensw"))
 END
 
 IF
+HasItem("CVJensw",Myself)
 !HasItemEquiped("CVJensw",Myself)
 !See(NearestEnemyOf(Myself))
 CombatCounter(0)

--- a/SandrahNPC/Setup-SandrahNPC.tp2
+++ b/SandrahNPC/Setup-SandrahNPC.tp2
@@ -8557,6 +8557,7 @@ COMPILE
 ~SandrahNPC\IWD/SanIWD_Dialogues.d~
 ~SandrahNPC\IWD/SanIWDGuy.d~
 ~SandrahNPC\IWD/koveras1.baf~
+~SandrahNPC\IWD/HOWTOEET.baf~
 ~SandrahNPC\IWD/brunos.baf~
 EXTEND_TOP
 ~CVSandra.bcs~ ~SandrahNPC\IWD/SanIWDtriggers.baf~


### PR DESCRIPTION
p_zombie made some changes for iwd, hope they are good:

1. Jenlig doesn't require her sword in IWD (to avoid glitches after removing all the items before traveling to IWD), but have it back once in BG1 again.
2. After traveling to HOW from Harbor master the party can come back to him and no blocking of main IWD content happens after it.